### PR TITLE
Revert "Fix truncateStringMax() method for two-codepoints symbols"

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
@@ -79,12 +79,7 @@ public class UnicodeUtil {
 
     // Try incrementing the code points from the end
     for (int i = length - 1; i >= 0; i--) {
-      int currentCodePoint = truncatedStringBuffer.codePointAt(i);
-      // Skip code point if it's a low surrogate
-      if (Character.isLowSurrogate((char) currentCodePoint)) {
-        continue;
-      }
-      int nextCodePoint = currentCodePoint + 1;
+      int nextCodePoint = truncatedStringBuffer.codePointAt(i) + 1;
       // No overflow
       if (nextCodePoint != 0 && Character.isValidCodePoint(nextCodePoint)) {
         // Get the offset in the truncated string buffer where the number of unicode characters = i

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetMetricsTruncation.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetMetricsTruncation.java
@@ -138,7 +138,6 @@ public class TestParquetMetricsTruncation {
     String test6 = "\uD800\uDFFF\uD800\uDFFF";
     // Increment the previous character
     String test6_2_expected = "\uD801\uDC00";
-    String test7 = "\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02";
 
     Comparator<CharSequence> cmp = Literal.of(test1).comparator();
     Assert.assertTrue("Truncated upper bound should be greater than or equal to the actual upper bound",
@@ -176,7 +175,5 @@ public class TestParquetMetricsTruncation {
     Assert.assertTrue("Test 4 byte UTF-8 character increment. Output must have one character with " +
         "the first character incremented", cmp.compare(
         truncateStringMax(Literal.of(test6), 1).value(), test6_2_expected) == 0);
-    Assert.assertTrue("Truncated upper bound should be greater than or equal to the actual upper bound",
-        cmp.compare(truncateStringMax(Literal.of(test7), 5).value(), test7) >= 0);
   }
 }


### PR DESCRIPTION
Reverts ikosyanenko/incubator-iceberg#1